### PR TITLE
Develop bms

### DIFF
--- a/src/SimCan.cpp
+++ b/src/SimCan.cpp
@@ -39,7 +39,9 @@ void SimCan::_transmit() {
         for(CanMessage msg : TRANSMIT_MSGS){
             uint8_t error = _can->sendMsgBuf(msg.id, CAN_FRAME, msg.dataLength, msg.data);
             if(_serial){
-                _serial->println("CAN Msg Sent - ID: " + String(msg.id) + " - Status: " + _getErrorDescription(error));
+                _serial->print("CAN MESSAGE SENT - ID: 0x"); 
+                _serial->print(msg.id, HEX); 
+                _serial->println(" - Status: " + _getErrorDescription(error));
             }
         }
 
@@ -54,15 +56,16 @@ void SimCan::_receive(){
     uint16_t canId = _can->getCanId();
 
     if(canId == BMS_REQUEST_ID){
-        _processCanRequest(len, buf);
+        _processBmsRequest(len, buf);
     }
 
     if(_serial){
         _serial->println("-----------------------------");
-        _serial->print("Get data from ID: 0x");
+        _serial->print("CAN MESSAGE RECEIVED - ID: 0x");
         _serial->println(canId, HEX);
 
         for (int i = 0; i < len; i++) { // print the data
+            _serial->print("0x");
             _serial->print(buf[i], HEX);
             _serial->print("\t");
         }
@@ -70,7 +73,7 @@ void SimCan::_receive(){
     }
 }
 
-void SimCan::_processCanRequest(uint8_t len, uint8_t buf[]){
+void SimCan::_processBmsRequest(uint8_t len, uint8_t buf[]){
 
     if(_serial) _serial->println("BMS CAN REQUEST RECEIVED!");
     
@@ -95,7 +98,7 @@ void SimCan::_processCanRequest(uint8_t len, uint8_t buf[]){
                 response[j+2] = BMS_RESPONSE_DATA[i][j];
             }
             // Send the message
-            uint8_t error = _can->sendMsgBuf(BMS_RESPONSE_ID, CAN_FRAME, BMS_RESPONSE_LENGTH[i+2], response);
+            uint8_t error = _can->sendMsgBuf(BMS_RESPONSE_ID, CAN_FRAME, BMS_RESPONSE_LENGTH[i]+2, response);
             if(_serial){
                 _serial->println("BMS RESPONSE SENT - PROPERTY: " + String(BMS_PROPERTY[i]) + " - Status: " + _getErrorDescription(error));
             }

--- a/src/SimCan.h
+++ b/src/SimCan.h
@@ -4,15 +4,61 @@
 #include "Sim.h"
 #include "mcp2515_can.h"
 
+struct CanMessage {
+    uint32_t id;
+    uint8_t dataLength;
+    uint8_t data[8];
+};
+
+// CAN Settings
 #define CAN_DEBUG_BAUD_RATE 115200
 #define CAN_CS_PIN          A5
-#define CAN_UPDATE_MS       1000
 #define CAN_FRAME           0
 
-#define CAN0_ID             0x14
-#define CAN0_DATA_LENGTH    8
-#define CAN1_ID             0x2D
-#define CAN1_DATA_LENGTH    8
+// Transmit Settings
+#define CAN_TRANSMIT_INTERVAL       200
+
+// Transmit Messages
+const CanMessage TEST1 = {0x14, 8, {0, 1, 2, 3, 4, 5, 6, 7}};
+const CanMessage TEST2 = {0x2D, 8, {7, 6, 5, 4, 3, 2, 1, 0}};
+const CanMessage TRANSMIT_MSGS[] = {TEST1, TEST2};
+
+// BMS Settings
+#define BMS_REQUEST_ID      0x201
+#define BMS_RESPONSE_ID     0x241
+#define NUM_BMS_PROPERTIES  9
+
+const uint8_t BMS_PROPERTY[NUM_BMS_PROPERTIES] =   {0x14,   // pack voltage
+                                                    0x15,   // pack current
+                                                    0x16,   // max cell voltage
+                                                    0x17,   // min cell voltage
+                                                    0x18,   // current status
+                                                    0x1A,   // state of charge
+                                                    0x1B,   // Temperatures
+                                                    0x1B,
+                                                    0x1B};  
+
+const uint8_t BMS_RESPONSE_LENGTH[NUM_BMS_PROPERTIES] =    {4,
+                                                            4, 
+                                                            2, 
+                                                            2, 
+                                                            2,
+                                                            4,
+                                                            3,
+                                                            3, 
+                                                            3};
+
+const uint8_t BMS_RESPONSE_DATA[NUM_BMS_PROPERTIES][4] =   {{0x00,0x00,0x40,0x42},    // 48.0
+                                                            {0xCD,0xCC,0x4C,0x3F},    // 0.8
+                                                            {0x04,0x10,0x00,0x00},    // 4100
+                                                            {0xD8,0x0E,0x00,0x00},    // 3800
+                                                            {0x93,0x00,0x00,0x00},    // DISCHARGING
+                                                            {0xC0,0x9E,0xE6,0x05},    // 99000000
+                                                            {0xFA,0x00,0x00,0x00},    // 250 (Internal Temp)
+                                                            {0x04,0x01,0x01,0x00},    // 260 (Battery Temp #1)
+                                                            {0x18,0x01,0x02,0x00}};   // 280 (Battery Temp #2)
+
+
 
 class SimCan : public Sim {
     public:
@@ -38,11 +84,13 @@ class SimCan : public Sim {
     private:
         mcp2515_can* _can; 
         Stream *_serial = NULL;
-        unsigned char _can0_data[CAN0_DATA_LENGTH] = {0, 1, 2, 3, 4, 5, 6, 7};
-        unsigned char _can1_data[CAN1_DATA_LENGTH] = {4, 3, 2, 1, 0, 0xF, 0xE, 0xD};
-        unsigned long long _can_last_update;
+        unsigned long long _last_transmit;
 
-        String getErrorDescription(uint8_t errorCode);
+        void _transmit();
+        void _receive();
+        void _processCanRequest(uint8_t len, uint8_t buf[]);
+
+        String _getErrorDescription(uint8_t errorCode);
 
 };
 

--- a/src/SimCan.h
+++ b/src/SimCan.h
@@ -4,6 +4,8 @@
 #include "Sim.h"
 #include "mcp2515_can.h"
 
+// This struct contains all the components of a CAN message. dataLength must be <= 8, 
+// and the first [dataLength] positions of data[] must contain valid data
 struct CanMessage {
     uint32_t id;
     uint8_t dataLength;
@@ -16,11 +18,11 @@ struct CanMessage {
 #define CAN_FRAME           0
 
 // Transmit Settings
-#define CAN_TRANSMIT_INTERVAL       200
+#define CAN_TRANSMIT_INTERVAL       2000
 
 // Transmit Messages
-const CanMessage TEST1 = {0x14, 8, {0, 1, 2, 3, 4, 5, 6, 7}};
-const CanMessage TEST2 = {0x2D, 8, {7, 6, 5, 4, 3, 2, 1, 0}};
+const CanMessage TEST1 = {0x14, 8, {0x15, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+const CanMessage TEST2 = {0x2D, 8, {0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00}};
 const CanMessage TRANSMIT_MSGS[] = {TEST1, TEST2};
 
 // BMS Settings
@@ -58,8 +60,6 @@ const uint8_t BMS_RESPONSE_DATA[NUM_BMS_PROPERTIES][4] =   {{0x00,0x00,0x40,0x42
                                                             {0x04,0x01,0x01,0x00},    // 260 (Battery Temp #1)
                                                             {0x18,0x01,0x02,0x00}};   // 280 (Battery Temp #2)
 
-
-
 class SimCan : public Sim {
     public:
 
@@ -86,10 +86,31 @@ class SimCan : public Sim {
         Stream *_serial = NULL;
         unsigned long long _last_transmit;
 
+        /**
+         * Transmit all CAN messages in TRANSMIT_MSGS array, emulating CAN Accessories
+         **/
         void _transmit();
-        void _receive();
-        void _processCanRequest(uint8_t len, uint8_t buf[]);
 
+        /**
+         * Print all new CAN messages over serial (if enabled). If a BMS request is received, 
+         * respond to it.
+         **/
+        void _receive();
+
+        /**
+         * Respond to a BMS request with some mock (static) data, emulating the BMS
+         * 
+         * @param len length in bytes of received message
+         * @param buf data buffer
+         **/       
+        void _processBmsRequest(uint8_t len, uint8_t buf[]);
+
+        /**
+         * Convert error code into descriptive error message
+         * 
+         * @param errorCode
+         * @return error message
+         **/ 
         String _getErrorDescription(uint8_t errorCode);
 
 };

--- a/src/SimCan.h
+++ b/src/SimCan.h
@@ -18,7 +18,7 @@ struct CanMessage {
 #define CAN_FRAME           0
 
 // Transmit Settings
-#define CAN_TRANSMIT_INTERVAL       2000
+#define CAN_TRANSMIT_INTERVAL 1000
 
 // Transmit Messages
 const CanMessage TEST1 = {0x14, 8, {0x15, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
@@ -28,37 +28,17 @@ const CanMessage TRANSMIT_MSGS[] = {TEST1, TEST2};
 // BMS Settings
 #define BMS_REQUEST_ID      0x201
 #define BMS_RESPONSE_ID     0x241
-#define NUM_BMS_PROPERTIES  9
+#define BMS_REQUEST_LENGTH  8
 
-const uint8_t BMS_PROPERTY[NUM_BMS_PROPERTIES] =   {0x14,   // pack voltage
-                                                    0x15,   // pack current
-                                                    0x16,   // max cell voltage
-                                                    0x17,   // min cell voltage
-                                                    0x18,   // current status
-                                                    0x1A,   // state of charge
-                                                    0x1B,   // Temperatures
-                                                    0x1B,
-                                                    0x1B};  
-
-const uint8_t BMS_RESPONSE_LENGTH[NUM_BMS_PROPERTIES] =    {4,
-                                                            4, 
-                                                            2, 
-                                                            2, 
-                                                            2,
-                                                            4,
-                                                            3,
-                                                            3, 
-                                                            3};
-
-const uint8_t BMS_RESPONSE_DATA[NUM_BMS_PROPERTIES][4] =   {{0x00,0x00,0x40,0x42},    // 48.0
-                                                            {0xCD,0xCC,0x4C,0x3F},    // 0.8
-                                                            {0x04,0x10,0x00,0x00},    // 4100
-                                                            {0xD8,0x0E,0x00,0x00},    // 3800
-                                                            {0x93,0x00,0x00,0x00},    // DISCHARGING
-                                                            {0xC0,0x9E,0xE6,0x05},    // 99000000
-                                                            {0xFA,0x00,0x00,0x00},    // 250 (Internal Temp)
-                                                            {0x04,0x01,0x01,0x00},    // 260 (Battery Temp #1)
-                                                            {0x18,0x01,0x02,0x00}};   // 280 (Battery Temp #2)
+const CanMessage BMS_RESPONSE[] =   {{BMS_RESPONSE_ID, 6, {0x14,0x01,0x00,0x00,0x40,0x42}}, // Pack Voltage         - 48.0
+                                    {BMS_RESPONSE_ID, 6, {0x15,0x01,0xCD,0xCC,0x4C,0x3F}},  // Pack Current         - 0.8
+                                    {BMS_RESPONSE_ID, 4, {0x16,0x01,0x04,0x10}},            // Max Cell Voltage     - 4100
+                                    {BMS_RESPONSE_ID, 4, {0x17,0x01,0xD8,0x0E}},            // Min Cell Voltage     - 3800
+                                    {BMS_RESPONSE_ID, 4, {0x18,0x01,0x93,0x00}},            // Current Status       - DISCHARGING
+                                    {BMS_RESPONSE_ID, 6, {0x1A,0x01,0xC0,0x9E,0xE6,0x05}},  // State of Charge      - 99000000
+                                    {BMS_RESPONSE_ID, 5, {0x1B,0x01,0xFA,0x00,0x00}},       // Internal Temperature - 250
+                                    {BMS_RESPONSE_ID, 5, {0x1B,0x01,0x04,0x01,0x01}},       // Battery Temp #1      - 260
+                                    {BMS_RESPONSE_ID, 5, {0x1B,0x01,0x18,0x01,0x02}}};      // Battery Temp #2      - 280
 
 class SimCan : public Sim {
     public:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,7 @@
 #include "SimEcu.h"
 #include "SimCan.h"
 
-#define CAN_DEBUG 0
+#define CAN_DEBUG 1
 
 #if CAN_DEBUG
     SimCan can(&Serial);


### PR DESCRIPTION
Improves CAN simulator class and adds full BMS simulation capability. Will now respond to CAN requests for data as if it was the BMS simulator. Tested against BMS at home and appears to function the same. 